### PR TITLE
Use HTTP 302 Found to prevent caching issues

### DIFF
--- a/src/main/scala/com/test/TestHttpApp.scala
+++ b/src/main/scala/com/test/TestHttpApp.scala
@@ -85,7 +85,7 @@ class TestHttpApp[F[_] <: AnyRef : Sync](contextBuilder: (Request[F], Config) =>
     }
 
   private val authedTrivial: AuthedRoutes[List[CommonProfile], F] =
-    Kleisli(_ => OptionT.liftF(MovedPermanently(Location(uri"/"))))
+    Kleisli(_ => OptionT.liftF(Found(Location(uri"/"))))
 
   val loginPages: HttpRoutes[F] =
     Router(


### PR DESCRIPTION
Fixes caching issues caused by Moved Permanently responses.