### PR TITLE
Add a more comfortable BlazeServer (shutdown port for tests)

### DIFF
--- a/src/main/scala/com/test/BlazeServer.scala
+++ b/src/main/scala/com/test/BlazeServer.scala
@@ -1,0 +1,80 @@
+package com.test
+
+import cats.effect._
+import cats.syntax.apply._
+import cats.syntax.functor._
+import com.comcast.ip4s.IpLiteralSyntax
+import fs2.INothing
+import fs2.concurrent.{Signal, SignallingRef}
+import fs2.io.net.Network
+import org.http4s.HttpApp
+import org.http4s.blaze.server.BlazeServerBuilder
+import org.slf4j.LoggerFactory
+
+object BlazeServer {
+
+  def apply[F[_]: Async]: Apply[F] = new Apply[F]
+
+  class Apply[F[_]: Async] {
+    def run(
+      app: HttpApp[F],
+      exitRef: Ref[F, ExitCode] = Ref.unsafe( ExitCode.Success )
+    ): F[ExitCode] = mkStream( app, exitRef ).compile.lastOrError
+  }
+
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  private def mkStream[F[_]: Async](
+    app: HttpApp[F],
+    exitRef: Ref[F, ExitCode]
+  ): fs2.Stream[F, ExitCode] =
+    fs2.Stream.eval( mkSignal[F] ).flatMap( mkStreamWithSignal( app, exitRef, _ ) )
+
+  private def mkStreamWithSignal[F[_]](
+    app: HttpApp[F],
+    exitRef: Ref[F, ExitCode],
+    stopSignal: SignallingRef[F, Boolean]
+  )( implicit F: Async[F] ): fs2.Stream[F, ExitCode] = {
+    val tcpServer  = tcpShutdownServer( stopSignal )
+    val httpServer = httpAppServer[F]( app, stopSignal, exitRef )
+
+    fs2.Stream.exec( F.pure(logger.info( "HTTP server starting" )) ) ++
+      tcpServer.merge( httpServer ) ++
+      fs2.Stream.exec( F.pure( logger.info( "HTTP server stopped" ) ) )
+  }
+
+  private def tcpShutdownServer[F[_]](
+    signalOut: SignallingRef[F, Boolean]
+  )( implicit F: Async[F] ): fs2.Stream[F, INothing] = {
+    def stream( ownSignal: SignallingRef[F, Boolean] ): fs2.Stream[F, INothing] =
+      Network[F]
+        .server( address = Some( ipv4"127.0.0.1" ), port = Some( port"8081" ) )
+        .evalMap(
+          _ =>
+            F.pure(logger.info( "HTTP server shutdown requested" ))
+              *> signalOut.set( true ) // emit signal to stop
+              *> ownSignal.set( true ) // stop the tcp server itself
+        )
+        .drain
+        .interruptWhen( ownSignal )
+
+    fs2.Stream.exec(
+      F.pure( logger.info( s"Listening on shutdown port 8081, to stop the server connect to http://localhost:8081" ) )
+    ) ++
+      fs2.Stream.force( mkSignal[F].map( stream ) )
+  }
+
+  private def httpAppServer[F[_]: Async](
+    app: HttpApp[F],
+    signal: Signal[F, Boolean],
+    exitRef: Ref[F, ExitCode]
+  ): fs2.Stream[F, ExitCode] =
+    BlazeServerBuilder[F]
+      .withHttpApp( app )
+      .bindHttp(8080, "localhost")
+      .withMaxHeadersLength(2 * 1024 * 1024)
+      .withoutBanner
+      .serveWhile( signal, exitRef )
+
+  private def mkSignal[F[_]: Concurrent]: F[SignallingRef[F, Boolean]] = SignallingRef[F, Boolean]( false )
+}

--- a/src/main/scala/com/test/MainIO.scala
+++ b/src/main/scala/com/test/MainIO.scala
@@ -2,17 +2,12 @@ package com.test
 
 import cats.effect._
 import cats.effect.std.Dispatcher
-import org.http4s.blaze.server.BlazeServerBuilder
 
 object MainIO extends IOApp {
 
   override def run(args: List[String]): IO[ExitCode] = {
     Dispatcher[IO].use( d =>
-    BlazeServerBuilder[IO]
-      .bindHttp(8080, "localhost")
-      .withMaxHeadersLength(2 * 1024 * 1024)
-      .withHttpApp(new TestHttpApp.App[IO](d).routedHttpApp)
-      .serve.compile.lastOrError
+      BlazeServer[IO].run(new TestHttpApp.App[IO](d).routedHttpApp)
     )
   }
 }

--- a/src/main/scala/com/test/MainZIO.scala
+++ b/src/main/scala/com/test/MainZIO.scala
@@ -3,16 +3,11 @@ package com.test
 import zio._
 import zio.interop.catz._
 import zio.interop.catz.implicits._
-import org.http4s.blaze.server.BlazeServerBuilder
 
 object MainZIO extends App {
 
-  def program: Task[ExitCode] =
-    BlazeServerBuilder[Task]
-      .bindHttp(8080, "localhost")
-      .withMaxHeadersLength(2 * 1024 * 1024)
-      .withHttpApp(new (TestHttpApp.ZioApp).routedHttpApp)
-      .serve.compile.lastOrError.map(e => ExitCode(e.code))
+  def program: Task[cats.effect.ExitCode] =
+    BlazeServer[Task].run(new (TestHttpApp.ZioApp).routedHttpApp)
 
   override def run(args: List[String]): URIO[zio.ZEnv, ExitCode] =
     ZIO.runtime[ZEnv].flatMap { implicit rts =>


### PR DESCRIPTION
This is a proposal to change BlazeServer initialisation

Main goal of these changes is to provide a way to gracefully shutdown the server

You can now connect to localhost:8081 to shutdown the launched server

Ignore/Close that PR if you found that too much for a demo program