### PR TITLE
Update to Zio 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ val catsVersion = "2.6.1"
 val circeVersion = "0.14.1"
 val pac4jVersion = "5.4.3"
 val http4sVersion = "0.23.13"
+val http4sBlazeVersion = "0.23.12"
 //val specs2Version = "3.8.9"
 
 // Only necessary for SNAPSHOT releases
@@ -15,8 +16,8 @@ libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-core" % catsVersion,
   "com.lihaoyi" %% "scalatags" % "0.11.1",
   "org.http4s" %% "http4s-dsl" % http4sVersion,
-  "org.http4s" %% "http4s-blaze-server" % http4sVersion,
-  "org.http4s" %% "http4s-blaze-client" % http4sVersion,
+  "org.http4s" %% "http4s-blaze-server" % http4sBlazeVersion,
+  "org.http4s" %% "http4s-blaze-client" % http4sBlazeVersion,
 //  "org.http4s" %% "http4s-scalatags" % http4sVersion,
   "org.pac4j" % "pac4j-core" % pac4jVersion,
   "org.pac4j" % "pac4j-cas" % pac4jVersion,
@@ -32,8 +33,8 @@ libraryDependencies ++= Seq(
   "org.bouncycastle" % "bcprov-jdk15on" % "1.69",
   "org.bouncycastle" % "bcutil-jdk15on" % "1.69",
   "org.bouncycastle" % "bcpkix-jdk15on" % "1.69",
-  "dev.zio" %% "zio" % "1.0.15",
-  "dev.zio" %% "zio-interop-cats" % "3.2.9.1"
+  "dev.zio" %% "zio" % "2.0.0",
+  "dev.zio" %% "zio-interop-cats" % "3.3.0"
 )
 
 scalacOptions ++= Seq("-language:implicitConversions", "-language:higherKinds", "-deprecation")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.6.2

--- a/src/main/scala/com/test/BlazeServer.scala
+++ b/src/main/scala/com/test/BlazeServer.scala
@@ -4,7 +4,6 @@ import cats.effect._
 import cats.syntax.apply._
 import cats.syntax.functor._
 import com.comcast.ip4s.IpLiteralSyntax
-import fs2.INothing
 import fs2.concurrent.{Signal, SignallingRef}
 import fs2.io.net.Network
 import org.http4s.HttpApp
@@ -45,8 +44,8 @@ object BlazeServer {
 
   private def tcpShutdownServer[F[_]](
     signalOut: SignallingRef[F, Boolean]
-  )( implicit F: Async[F] ): fs2.Stream[F, INothing] = {
-    def stream( ownSignal: SignallingRef[F, Boolean] ): fs2.Stream[F, INothing] =
+  )( implicit F: Async[F] ): fs2.Stream[F, Nothing] = {
+    def stream( ownSignal: SignallingRef[F, Boolean] ): fs2.Stream[F, Nothing] =
       Network[F]
         .server( address = Some( ipv4"127.0.0.1" ), port = Some( port"8081" ) )
         .evalMap(

--- a/src/main/scala/com/test/ScalatagsInstances.scala
+++ b/src/main/scala/com/test/ScalatagsInstances.scala
@@ -6,10 +6,10 @@ import org.http4s.headers.`Content-Type`
 import scalatags.Text.TypedTag
 
 trait ScalatagsInstances {
-  implicit def htmlContentEncoder[F[_]](implicit charset: Charset = DefaultCharset): EntityEncoder[F, TypedTag[String]] =
+  implicit def htmlContentEncoder[F[_]](implicit charset: Charset = Charset.`UTF-8`): EntityEncoder[F, TypedTag[String]] =
     contentEncoder(html)
 
-  private def contentEncoder[F[_], C <: TypedTag[String]](mediaType: MediaType)(implicit charset: Charset = DefaultCharset): EntityEncoder[F, C] =
+  private def contentEncoder[F[_], C <: TypedTag[String]](mediaType: MediaType)(implicit charset: Charset = Charset.`UTF-8`): EntityEncoder[F, C] =
     EntityEncoder.stringEncoder(charset).contramap[C](content => content.render)
       .withContentType(`Content-Type`(mediaType, charset))
 }

--- a/src/main/scala/com/test/TestHttpApp.scala
+++ b/src/main/scala/com/test/TestHttpApp.scala
@@ -18,9 +18,7 @@ import org.pac4j.core.profile.{CommonProfile, ProfileManager}
 import org.pac4j.http4s.{Http4sWebContext, _}
 import scalatags.Text.all._
 import scalatags.Text
-import zio._
-import zio.blocking.Blocking
-import zio.clock.Clock
+import zio.{Clock, Task, Unsafe}
 
 import scala.jdk.CollectionConverters._
 
@@ -143,7 +141,7 @@ object TestHttpApp {
   class App[F[_] <: AnyRef : Sync]( dispatcher: Dispatcher[F] )
     extends TestHttpApp[F](Http4sWebContext.withDispatcherInstance(dispatcher))
 
-  class ZioApp( implicit runtime: zio.Runtime[Clock & Blocking] ) extends TestHttpApp[Task](
-    ( req, conf ) => new Http4sWebContext[Task]( req, conf.getSessionStore, runtime.unsafeRun( _ ) )
+  class ZioApp( implicit runtime: zio.Runtime[Clock] ) extends TestHttpApp[Task](
+    ( req, conf ) => new Http4sWebContext[Task]( req, conf.getSessionStore, Unsafe.unsafe{ implicit u => runtime.unsafe.run( _ ).getOrThrow() } )
   )
 }


### PR DESCRIPTION
This updates Zio example to newly released Zio 2 version reflecting all the changes in the runtime. Additionally I fixed some deprecation warnings in code and split http4s version into separate for core and blaze as they now have separate release schedules.