### PR TITLE
Update pac4j to 6.0.2 and and http4s-pac4j to 5.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ scalaVersion := "2.13.13"
 val catsVersion = "2.10.0"
 //val catsEffectVersion = "3.2.9"
 val circeVersion = "0.14.1"
-val pac4jVersion = "5.7.3"
+val pac4jVersion = "6.0.2"
 val http4sVersion = "0.23.26"
 val http4sBlazeVersion = "0.23.15"
 //val specs2Version = "3.8.9"
@@ -26,7 +26,7 @@ libraryDependencies ++= Seq(
   "org.pac4j" % "pac4j-oauth" % pac4jVersion,
   "org.pac4j" % "pac4j-oidc" % pac4jVersion,
   "org.pac4j" % "pac4j-saml" % pac4jVersion,
-  "org.pac4j" %% "http4s-pac4j" % "4.4.0",
+  "org.pac4j" %% "http4s-pac4j" % "5.0.0-SNAPSHOT",
   "org.slf4j" % "slf4j-api" % "2.0.13",
   "org.http4s" %% "http4s-server" % http4sVersion,
   "ch.qos.logback" % "logback-classic" % "1.5.5",

--- a/src/main/scala/com/test/DemoConfigFactory.scala
+++ b/src/main/scala/com/test/DemoConfigFactory.scala
@@ -1,20 +1,17 @@
 package com.test
 
-import cats.effect.{IO, Sync}
-import org.pac4j.core.authorization.authorizer.RequireAnyRoleAuthorizer
+import cats.effect.Sync
 import org.pac4j.core.authorization.generator.AuthorizationGenerator
 import org.pac4j.core.client.Clients
 import org.pac4j.core.config.{Config, ConfigFactory}
-import org.pac4j.core.context.WebContext
-import org.pac4j.core.context.session.SessionStore
-import org.pac4j.core.profile.{CommonProfile, UserProfile}
+import org.pac4j.core.context.CallContext
+import org.pac4j.core.profile.UserProfile
 import org.pac4j.http.client.indirect.FormClient
 import org.pac4j.http.credentials.authenticator.test.SimpleTestUsernamePasswordAuthenticator
-import org.pac4j.http4s.{DefaultHttpActionAdapter, Http4sCacheSessionStore, Http4sCookieSessionStore}
+import org.pac4j.http4s.{DefaultHttpActionAdapter, Http4sCacheSessionStore}
 import org.pac4j.oauth.client.FacebookClient
 import org.pac4j.oidc.client.OidcClient
 import org.pac4j.oidc.config.OidcConfiguration
-import org.pac4j.oidc.profile.OidcProfile
 import org.pac4j.saml.client.SAML2Client
 import org.pac4j.saml.config.SAML2Configuration
 
@@ -32,7 +29,7 @@ class DemoConfigFactory[F[_] <: AnyRef : Sync] extends ConfigFactory {
     //config.addAuthorizer("admin", new RequireAnyRoleAuthorizer[_ <: CommonProfile]("ROLE_ADMIN"))
     //config.addAuthorizer("custom", new CustomAuthorizer)
     config.setHttpActionAdapter(new DefaultHttpActionAdapter[F])  // <-- Render a nicer page
-    config.setSessionStore(new Http4sCacheSessionStore[F]())
+    config.setSessionStoreFactory(_ => new Http4sCacheSessionStore[F]())
 //    config.setSessionStore(new Http4sCookieSessionStore[F]{})
     config
   }
@@ -47,8 +44,8 @@ class DemoConfigFactory[F[_] <: AnyRef : Sync] extends ConfigFactory {
     val oidcClient = new OidcClient(oidcConfiguration)
 
     val authorizationGenerator = new AuthorizationGenerator {
-      override def generate(context: WebContext, sessionStore: SessionStore, profile: UserProfile): Optional[UserProfile] = {
-        profile.addRole("ROLE_ADMIN")
+      override def generate(ctx: CallContext, profile: UserProfile): Optional[UserProfile] = {
+      profile.addRole("ROLE_ADMIN")
         Optional.of(profile)
       }
     }


### PR DESCRIPTION
This update pac4j to `6.0.2` and pac4j-https to `5.0.0`.

Related to https://github.com/pac4j/http4s-pac4j/pull/38

pac4j-https version is a `SNAPSHOT` until it gets released.